### PR TITLE
Simplify codecov actions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -35,10 +35,11 @@ jobs:
       - name: Install thevenin
         run: |
           python -m pip install --upgrade pip
+          python -m pip install --upgrade nox
           pip install .[tests]
 
-      - name: Pytest with coverage
-        run: pytest --cov=thevenin --cov-report=xml tests/
+      - name: Collect coverage
+        run: nox -s tests -- codecov
 
       - name: Upload to codecov
         uses: codecov/codecov-action@v5

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import importlib
 
 import nox
 
@@ -89,13 +88,17 @@ def run_pytest(session: nox.Session) -> None:
     you can specify the number of workers using an int, e.g., parallel=4.
 
     """
-    package = importlib.util.find_spec('thevenin')
-    coverage_folder = os.path.dirname(package.origin)
-
     if 'no-reports' in session.posargs:
         command = [
             'pytest',
-            f'--cov={coverage_folder}',  # for editable or site-packages
+            '--cov=thevenin',
+            'tests/',
+        ]
+    elif 'codecov' in session.posargs:
+        command = [
+            'pytest',
+            '--cov=thevenin',
+            '--cov-report=xml',
             'tests/',
         ]
     else:
@@ -103,7 +106,7 @@ def run_pytest(session: nox.Session) -> None:
 
         command = [
             'pytest',
-            '--cov=src/thevenin',
+            '--cov=thevenin',
             '--cov-report=html:reports/htmlcov',
             '--cov-report=xml:reports/coverage.xml',
             '--junitxml=reports/junit.xml',


### PR DESCRIPTION
# Description
Tie in nox to codecov workflow. New `-- codecov` argument for the `nox` session is used for this purpose. This keeps commands together in one conventient location rather than spread across many workflows/files.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (any other clean up, maintenance, etc.)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.